### PR TITLE
[Fix]: Let assignment of annotations to Pod without any existing ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ KIND ?= kind
 DOCKER ?= docker
 DOCKER_ARGS ?= --load
 APP_NAME ?= ghcr.io/nccloud/metadata-reflector
-TAG ?= 0.1.0-dev
+TAG ?= 0.1.1-dev
 IMG ?= ${APP_NAME}:${TAG}
 KIND_IMAGE ?= kindest/node:v1.31.0
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ KIND ?= kind
 DOCKER ?= docker
 DOCKER_ARGS ?= --load
 APP_NAME ?= ghcr.io/nccloud/metadata-reflector
-TAG ?= 0.1.1-dev
+TAG ?= 0.2.1-dev
 IMG ?= ${APP_NAME}:${TAG}
 KIND_IMAGE ?= kindest/node:v1.31.0
 

--- a/internal/controllers/reflector/annotations.go
+++ b/internal/controllers/reflector/annotations.go
@@ -41,6 +41,10 @@ func (r *Controller) setAnnotations(annotations map[string]string, pod *v1.Pod) 
 func (r *Controller) unsetAnnotations(annotations []string, pod *v1.Pod) bool {
 	anyAnnotationUnset := false
 
+	if pod.Annotations == nil {
+		return anyAnnotationUnset
+	}
+
 	for _, annotation := range annotations {
 		if _, annotationExists := pod.Annotations[annotation]; !annotationExists {
 			continue

--- a/internal/controllers/reflector/annotations.go
+++ b/internal/controllers/reflector/annotations.go
@@ -17,6 +17,10 @@ func (r *Controller) getReflectedAnnotations(labelsToReflect string) map[string]
 func (r *Controller) setAnnotations(annotations map[string]string, pod *v1.Pod) bool {
 	podUpdated := false
 
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+
 	for key, value := range annotations {
 		annotationValue, annotationOk := pod.Annotations[key]
 		if annotationOk && annotationValue == value {

--- a/internal/controllers/reflector/annotations_test.go
+++ b/internal/controllers/reflector/annotations_test.go
@@ -136,3 +136,27 @@ func TestController_unsetAnnotations(t *testing.T) {
 	assert.True(t, annotationsUnset, "annotationsUnset should be true because annotation1 was removed")
 	assert.Equal(t, expectedAnnotations, pod.Annotations, "remaining annotations should match the expected annotations")
 }
+
+func TestController_unsetAnnotationsFromPodWithoutAnyExistingOnes(t *testing.T) {
+	mockClient := new(mockKubernetesClient.MockKubernetesClient)
+
+	logger := zap.New()
+	config := &common.Config{}
+
+	controller := &Controller{
+		kubeClient: mockClient,
+		logger:     logger,
+		config:     config,
+	}
+
+	annotationsToUnset := []string{"annotation1", "annotation3"}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+		},
+	}
+
+	annotationsUnset := controller.unsetAnnotations(annotationsToUnset, pod)
+
+	assert.False(t, annotationsUnset, "annotationsUnset should be false because there are no annotations to unset")
+}

--- a/internal/controllers/reflector/annotations_test.go
+++ b/internal/controllers/reflector/annotations_test.go
@@ -70,6 +70,40 @@ func TestController_setAnnotations(t *testing.T) {
 	assert.Equal(t, expectedAnnotations, pod.Annotations, "pod annotations should match the expected annotations")
 }
 
+func TestController_setAnnotationsToPodWithoutAnyExistingOnes(t *testing.T) {
+	mockClient := new(mockKubernetesClient.MockKubernetesClient)
+
+	logger := zap.New()
+	config := &common.Config{}
+
+	controller := &Controller{
+		kubeClient: mockClient,
+		logger:     logger,
+		config:     config,
+	}
+
+	annotationsToSet := map[string]string{
+		"annotation1": "value1",
+		"annotation2": "value2",
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+		},
+	}
+
+	expectedAnnotations := map[string]string{
+		"annotation1": "value1",
+		"annotation2": "value2",
+	}
+
+	podUpdated := controller.setAnnotations(annotationsToSet, pod)
+
+	assert.True(t, podUpdated, "pod with no existing annotations should be updated")
+	assert.Equal(t, expectedAnnotations, pod.Annotations, "pod annotations should match the expected annotations")
+}
+
 func TestController_unsetAnnotations(t *testing.T) {
 	mockClient := new(mockKubernetesClient.MockKubernetesClient)
 

--- a/internal/controllers/reflector/labels.go
+++ b/internal/controllers/reflector/labels.go
@@ -140,6 +140,10 @@ func (r *Controller) unsetReflectedLabels(ctx context.Context, deployment *appsv
 func (r *Controller) setLabels(labels map[string]string, pod *v1.Pod) bool {
 	podUpdated := false
 
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+
 	for key, value := range labels {
 		podLabelValue, ok := pod.Labels[key]
 		if ok && value == podLabelValue {

--- a/internal/controllers/reflector/labels.go
+++ b/internal/controllers/reflector/labels.go
@@ -165,6 +165,10 @@ func (r *Controller) setLabels(labels map[string]string, pod *v1.Pod) bool {
 func (r *Controller) unsetLabels(labels []string, pod *v1.Pod) bool {
 	anyLabelDeleted := false
 
+	if pod.Labels == nil {
+		return anyLabelDeleted
+	}
+
 	for _, label := range labels {
 		if _, ok := pod.Labels[label]; !ok {
 			continue

--- a/internal/controllers/reflector/labels_test.go
+++ b/internal/controllers/reflector/labels_test.go
@@ -623,6 +623,11 @@ func TestController_unsetLabelsFromPodWithoutAnyExistingOnes(t *testing.T) {
 		},
 	}
 
+	labelsToUnset := []string{
+		"key2",
+		"key3", // label not present in pod, so nothing should be deleted
+	}
+
 	anyLabelDeleted := controller.unsetLabels(labelsToUnset, pod)
 
 	assert.False(t, anyLabelDeleted, "No labels should be updated")

--- a/internal/controllers/reflector/labels_test.go
+++ b/internal/controllers/reflector/labels_test.go
@@ -539,6 +539,37 @@ func TestController_setLabels(t *testing.T) {
 	assert.Equal(t, "value3", pod.Labels["key3"], "Label 'key3' should be added.")
 }
 
+func TestController_setLabelsToPodWithoutAnyExistingOnes(t *testing.T) {
+	mockClient := new(mockKubernetesClient.MockKubernetesClient)
+
+	logger := zap.New()
+	config := &common.Config{}
+
+	controller := &Controller{
+		kubeClient: mockClient,
+		logger:     logger,
+		config:     config,
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+
+	labelsToSet := map[string]string{
+		"key1": "value1", // new label, should be added
+		"key3": "value3", // new label, should be added
+	}
+
+	updated := controller.setLabels(labelsToSet, pod)
+
+	assert.True(t, updated, "The pod should be updated because labels were set.")
+	assert.Equal(t, "value1", pod.Labels["key1"], "Label 'key1' should be added.")
+	assert.Equal(t, "value3", pod.Labels["key3"], "Label 'key3' should be added.")
+}
+
 func TestController_unsetLabels(t *testing.T) {
 	mockKubernetesClient := new(mockKubernetesClient.MockKubernetesClient)
 
@@ -571,6 +602,30 @@ func TestController_unsetLabels(t *testing.T) {
 
 	assert.True(t, anyLabelDeleted, "Some labels should be deleted.")
 	assert.Equal(t, map[string]string{"key1": "value1"}, pod.Labels, "Pod labels should be different.")
+}
+
+func TestController_unsetLabelsFromPodWithoutAnyExistingOnes(t *testing.T) {
+	mockKubernetesClient := new(mockKubernetesClient.MockKubernetesClient)
+
+	logger := zap.New()
+	config := &common.Config{}
+
+	controller := &Controller{
+		kubeClient: mockKubernetesClient,
+		logger:     logger,
+		config:     config,
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+
+	anyLabelDeleted := controller.unsetLabels(labelsToUnset, pod)
+
+	assert.False(t, anyLabelDeleted, "No labels should be updated")
 }
 
 func TestController_unsetExcessiveLabels(t *testing.T) {


### PR DESCRIPTION
<!-- Describe the purpose of the PR -->
## What does this change resolve?
- Fixes the following error:
`2024-12-18T11:36:46.057252474Z panic: assignment to entry in nil map`
which occurs when controller tries to set annotations to Pod without existing ones.

## Open questions or TODOs before merging if any
<!-- - [ ] Use github checklists. When solved, check the box -->
