### PR TITLE
Skip Not Found Deployments & Check for Unused Public Functions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,6 @@
 name: Lint
 
 on:
-  push:
   pull_request:
 
 permissions:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+  push:
   pull_request:
 
 permissions:
@@ -20,3 +21,6 @@ jobs:
         run: go mod download
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
+      - name: Run deadcode
+        run: |
+          make check-deadcode

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ cluster-delete: ## Delete the kind cluster.
 fmt: ## Run gofumpt.
 	@./helper.sh fmt
 
+.PHONY: check-deadcode
+check-deadcode: ## Run deadcode.
+	@./helper.sh check_deadcode
+
 .PHONY: lint
 lint: fmt ## Run linter.
 	@./helper.sh lint

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
 	k8s.io/api v0.35.1
@@ -49,6 +48,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/helper.sh
+++ b/helper.sh
@@ -3,6 +3,7 @@
 GOLANGCI_LINT_VERSION="v2.10.1"
 GOFUMPT_VERSION="v0.9.2"
 MOCKERY_VERSION="v3.6.4"
+DEADCODE_VERSION="v0.42.0"
 
 prerequisites() {
   if [[ "$(golangci-lint --version 2>&1)" != *"$GOLANGCI_LINT_VERSION"* ]]; then
@@ -14,15 +15,23 @@ prerequisites() {
   if [[ "$(mockery --version 2>&1)" != *"$MOCKERY_VERSION"* ]]; then
     go install github.com/vektra/mockery/v3@"${MOCKERY_VERSION}"
   fi
+  if [[ "$(deadcode --version 2>&1)" != *"$DEADCODE_VERSION"* ]]; then
+    go install golang.org/x/tools/cmd/deadcode@"${DEADCODE_VERSION}"
+  fi
 }
 
 fmt() {
     gofumpt -l -w .
 }
 
+check_deadcode() {
+    deadcode ./...
+}
+
 lint() {
   fmt
   golangci-lint run
+  check_deadcode
 }
 
 generate() {

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -13,16 +13,6 @@ func Must(err error) {
 	}
 }
 
-func MustReturn[T any](t T, err error) T {
-	Must(err)
-
-	return t
-}
-
-func PointerTo[T any](t T) *T {
-	return new(t)
-}
-
 func MapHasPrefix(prefix string, data map[string]string) bool {
 	for key := range data {
 		if strings.HasPrefix(key, prefix) {

--- a/internal/common/utils_test.go
+++ b/internal/common/utils_test.go
@@ -27,38 +27,6 @@ func TestMust_PanicsOnError(t *testing.T) {
 	t.Errorf("did not panic")
 }
 
-func TestMustReturn(t *testing.T) {
-	errorPossibleFunction := func(a bool) (bool, error) {
-		return a, nil
-	}
-
-	result := MustReturn(errorPossibleFunction(true))
-
-	assert.True(t, result)
-}
-
-func TestMustReturn_PanicsOnError(t *testing.T) {
-	errorPossibleFunction := func(a bool) (bool, error) {
-		return a, errors.New("error occured")
-	}
-
-	defer func() {
-		_ = recover()
-	}()
-
-	MustReturn(errorPossibleFunction(true))
-
-	t.Errorf("did not panic")
-}
-
-func TestPointerTo(t *testing.T) {
-	value := 1
-
-	result := new(value)
-
-	assert.Equal(t, &value, result)
-}
-
 func TestMapHasPrefix(t *testing.T) {
 	type args struct {
 		prefix string


### PR DESCRIPTION
<!-- Describe the purpose of the PR -->
## What does this change resolve?
- After introducing periodic requeues of all objects in https://github.com/NCCloud/metadata-reflector/pull/70, if the source deployment gets deleted, the operator will treat it as an error and reconcile permanently, while it should just forget the object. This PR adds logic for skipping "Not Found" errors
- Add an additional `deadcode` check to detect unused exported functions. The `unused` linter in `golangci-lint` skips such functions to avoid false positives in packages, since they can be consumed by other applications that will use these functions. This is not the case for this controller at the moment